### PR TITLE
HTTP Status がエラー対象の場合の処理追加

### DIFF
--- a/corp.go
+++ b/corp.go
@@ -23,6 +23,7 @@ package corp
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -144,7 +145,7 @@ func responseByURLBuilder(builder request.URLBuilder) (Response, error) {
 		if len(strs) == 2 {
 			return res, fmt.Errorf("%s:%s", strs[0], strs[1])
 		}
-		return res, fmt.Errorf(str)
+		return res, errors.New(str)
 	}
 	if statusCode == http.StatusForbidden {
 		return res, fmt.Errorf(

--- a/corp.go
+++ b/corp.go
@@ -33,16 +33,17 @@ var (
 	// 法人番号 Web-API アプリケーション ID
 	appID string
 
-	fetch = func(URL string, options interface{}) ([]byte, error) {
+	fetch = func(URL string, options interface{}) (int, []byte, error) {
 		var body []byte
 
 		res, err := http.Get(URL)
 		if err != nil {
-			return body, err
+			return http.StatusInternalServerError, body, err
 		}
 		defer res.Body.Close()
 
-		return io.ReadAll(res.Body)
+		body, err = io.ReadAll(res.Body)
+		return res.StatusCode, body, err
 	}
 )
 
@@ -111,7 +112,7 @@ SetFetch は法人番号 Web-API からデータ取得処理を設定します�
 
 標準では単純な fetch 処理が利用可能です。ログ処理など特別な事情がある場合に利用してください。
 */
-func SetFetch(f func(URL string, options interface{}) ([]byte, error)) {
+func SetFetch(f func(URL string, options interface{}) (int, []byte, error)) {
 	fetch = f
 }
 
@@ -125,9 +126,10 @@ func responseByURLBuilder(builder request.URLBuilder) (Response, error) {
 		return Response{}, err
 	}
 
+	var statusCode int
 	var body []byte
 	var res Response
-	body, err = fetch(u.String(), nil)
+	statusCode, body, err = fetch(u.String(), nil)
 	if err != nil {
 		return Response{}, err
 	}

--- a/corp_test.go
+++ b/corp_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/fillin-inc/go-corp/request"
@@ -17,7 +18,7 @@ var (
 )
 
 func TestByNumber(t *testing.T) {
-	t.Run("simgle corporate number", func(t *testing.T) {
+	t.Run("Basic Usage", func(t *testing.T) {
 		ts := testServer(http.StatusOK, "./testdata/response/by_number.xml")
 		defer ts.Close()
 
@@ -46,7 +47,7 @@ func TestByNumber(t *testing.T) {
 		}
 	})
 
-	t.Run("multiple corporate numbers", func(t *testing.T) {
+	t.Run("Multiple Corporate Numbers", func(t *testing.T) {
 		ts := testServer(http.StatusOK, "./testdata/response/by_numbers.xml")
 		defer ts.Close()
 
@@ -82,97 +83,361 @@ func TestByNumber(t *testing.T) {
 			t.Errorf("corporation name is wtong. result:%s expected:%s", res.Corporations[1].Name, "群馬県")
 		}
 	})
+
+	t.Run("Errors", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			statusCode    int
+			contentType   string
+			content       string
+			expectedError string
+		}{
+			{
+				"HTTP_Status_400",
+				http.StatusBadRequest,
+				"application/csv",
+				"042,法人番号は10件以内で指定してください。",
+				"042:法人番号は10件以内で指定してください。",
+			},
+			{
+				"HTTP_Status_403",
+				http.StatusForbidden,
+				"text/html",
+				"",
+				"同一アプリケーションIDで一定期間内に多数のアクセスが実行されたため制限されています。",
+			},
+			{
+				"HTTP_Status_404",
+				http.StatusNotFound,
+				"text/html",
+				"",
+				"アプリケーションIDが登録されていないまたは無効です。",
+			},
+			{
+				"HTTP_Status_500",
+				http.StatusInternalServerError,
+				"text/html",
+				"",
+				"法人番号システム Web-API に問題が発生しています。",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				ts := testErrorServer(test.statusCode, test.contentType, test.content)
+				defer ts.Close()
+
+				SetAppID("your-token")
+				setTestEnvToRequest(ts)
+
+				_, err := ByNumber(testFillinCorpNum)
+				if err == nil {
+					t.Errorf("No error occurred.")
+				}
+
+				if strings.TrimSpace(err.Error()) != test.expectedError {
+					t.Log(err.Error())
+					t.Log(test.expectedError)
+				}
+			})
+		}
+	})
 }
 
 func TestByNumberWithHistory(t *testing.T) {
-	ts := testServer(http.StatusOK, "./testdata/response/by_number_with_history.xml")
-	defer ts.Close()
+	t.Run("Basic Usage", func(t *testing.T) {
+		ts := testServer(http.StatusOK, "./testdata/response/by_number_with_history.xml")
+		defer ts.Close()
 
-	SetAppID("your-token")
-	setTestEnvToRequest(ts)
+		SetAppID("your-token")
+		setTestEnvToRequest(ts)
 
-	res, err := ByNumberWithHistory(testFillinCorpNum)
-	if err != nil {
-		t.Errorf("error! %v", err)
-	}
-
-	if res.Count != 3 {
-		t.Errorf("count value is wrong. result:%d expected:%d", res.Count, 3)
-	}
-
-	if len(res.Corporations) != 3 {
-		t.Errorf("corporations length is wtong. result:%d expected:%d", len(res.Corporations), 3)
-	}
-
-	postCodes := []string{"3700849", "3700813", "3700069"}
-	for i, postCode := range postCodes {
-		corp := res.Corporations[i]
-		if corp.CorporateNumber != testFillinCorpNum {
-			t.Errorf("corporation name is wtong. result:%d expected:%d", corp.CorporateNumber, testFillinCorpNum)
+		res, err := ByNumberWithHistory(testFillinCorpNum)
+		if err != nil {
+			t.Errorf("error! %v", err)
 		}
 
-		if res.Corporations[i].PostCode != postCode {
-			t.Errorf("corporation name is wtong. result:%s expected:%s", corp.PostCode, postCode)
+		if res.Count != 3 {
+			t.Errorf("count value is wrong. result:%d expected:%d", res.Count, 3)
 		}
-	}
+
+		if len(res.Corporations) != 3 {
+			t.Errorf("corporations length is wtong. result:%d expected:%d", len(res.Corporations), 3)
+		}
+
+		postCodes := []string{"3700849", "3700813", "3700069"}
+		for i, postCode := range postCodes {
+			corp := res.Corporations[i]
+			if corp.CorporateNumber != testFillinCorpNum {
+				t.Errorf("corporation name is wtong. result:%d expected:%d", corp.CorporateNumber, testFillinCorpNum)
+			}
+
+			if res.Corporations[i].PostCode != postCode {
+				t.Errorf("corporation name is wtong. result:%s expected:%s", corp.PostCode, postCode)
+			}
+		}
+	})
+
+	t.Run("Errors", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			statusCode    int
+			contentType   string
+			content       string
+			expectedError string
+		}{
+			{
+				"HTTP_Status_400",
+				http.StatusBadRequest,
+				"application/csv",
+				"042,法人番号は10件以内で指定してください。",
+				"042:法人番号は10件以内で指定してください。",
+			},
+			{
+				"HTTP_Status_403",
+				http.StatusForbidden,
+				"text/html",
+				"",
+				"同一アプリケーションIDで一定期間内に多数のアクセスが実行されたため制限されています。",
+			},
+			{
+				"HTTP_Status_404",
+				http.StatusNotFound,
+				"text/html",
+				"",
+				"アプリケーションIDが登録されていないまたは無効です。",
+			},
+			{
+				"HTTP_Status_500",
+				http.StatusInternalServerError,
+				"text/html",
+				"",
+				"法人番号システム Web-API に問題が発生しています。",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				ts := testErrorServer(test.statusCode, test.contentType, test.content)
+				defer ts.Close()
+
+				SetAppID("your-token")
+				setTestEnvToRequest(ts)
+
+				_, err := ByNumber(testFillinCorpNum)
+				if err == nil {
+					t.Errorf("No error occurred.")
+				}
+
+				if strings.TrimSpace(err.Error()) != test.expectedError {
+					t.Errorf("Unexpected error received: %s, expected: %s", err.Error(), test.expectedError)
+				}
+			})
+		}
+	})
 }
 
 func TestDiffSearch(t *testing.T) {
-	ts := testServer(http.StatusOK, "./testdata/response/diff_search.xml")
-	defer ts.Close()
+	t.Run("Basic Usage", func(t *testing.T) {
+		ts := testServer(http.StatusOK, "./testdata/response/diff_search.xml")
+		defer ts.Close()
 
-	SetAppID("your-token")
-	setTestEnvToRequest(ts)
+		SetAppID("your-token")
+		setTestEnvToRequest(ts)
 
-	res, err := DiffSearch("2021-06-09", "2021-06-09", "10202")
-	if err != nil {
-		t.Errorf("error! %v", err)
-	}
+		res, err := DiffSearch("2021-06-09", "2021-06-09", "10202")
+		if err != nil {
+			t.Errorf("error! %v", err)
+		}
 
-	if res.Count != 1 {
-		t.Errorf("count value is wrong. result:%d expected:%d", res.Count, 1)
-	}
+		if res.Count != 1 {
+			t.Errorf("count value is wrong. result:%d expected:%d", res.Count, 1)
+		}
 
-	if len(res.Corporations) != 1 {
-		t.Errorf("corporations length is wtong. result:%d expected:%d", len(res.Corporations), 1)
-	}
+		if len(res.Corporations) != 1 {
+			t.Errorf("corporations length is wtong. result:%d expected:%d", len(res.Corporations), 1)
+		}
 
-	if res.Corporations[0].CorporateNumber != testFillinCorpNum {
-		t.Errorf("corporation name is wtong. result:%d expected:%d", res.Corporations[0].CorporateNumber, testFillinCorpNum)
-	}
+		if res.Corporations[0].CorporateNumber != testFillinCorpNum {
+			t.Errorf("corporation name is wtong. result:%d expected:%d", res.Corporations[0].CorporateNumber, testFillinCorpNum)
+		}
 
-	if res.Corporations[0].Name != "株式会社フィルイン" {
-		t.Errorf("corporation name is wtong. result:%s expected:%s", res.Corporations[0].Name, "株式会社フィルイン")
-	}
+		if res.Corporations[0].Name != "株式会社フィルイン" {
+			t.Errorf("corporation name is wtong. result:%s expected:%s", res.Corporations[0].Name, "株式会社フィルイン")
+		}
+	})
+
+	t.Run("Errors", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			from          string
+			to            string
+			address       string
+			statusCode    int
+			contentType   string
+			content       string
+			expectedError string
+		}{
+			{
+				"HTTP_Status_400",
+				"2015-06-09",
+				"2015-06-09",
+				"10202",
+				http.StatusBadRequest,
+				"application/csv",
+				"013,取得期間開始日は2015-12-01以降を指定してください。",
+				"013:取得期間開始日は2015-12-01以降を指定してください。",
+			},
+			{
+				"HTTP_Status_403",
+				"2021-06-09",
+				"2021-06-09",
+				"10202",
+				http.StatusForbidden,
+				"text/html",
+				"",
+				"同一アプリケーションIDで一定期間内に多数のアクセスが実行されたため制限されています。",
+			},
+			{
+				"HTTP_Status_404",
+				"2021-06-09",
+				"2021-06-09",
+				"10202",
+				http.StatusNotFound,
+				"text/html",
+				"",
+				"アプリケーションIDが登録されていないまたは無効です。",
+			},
+			{
+				"HTTP_Status_500",
+				"2021-06-09",
+				"2021-06-09",
+				"10202",
+				http.StatusInternalServerError,
+				"text/html",
+				"",
+				"法人番号システム Web-API に問題が発生しています。",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				ts := testErrorServer(test.statusCode, test.contentType, test.content)
+				defer ts.Close()
+
+				SetAppID("your-token")
+				setTestEnvToRequest(ts)
+
+				_, err := DiffSearch(test.from, test.to, test.address)
+				if err == nil {
+					t.Errorf("No error occurred.")
+				}
+
+				if strings.TrimSpace(err.Error()) != test.expectedError {
+					t.Errorf("Unexpected error received: %s, expected: %s", err.Error(), test.expectedError)
+				}
+			})
+		}
+	})
 }
 
 func TestNameSearch(t *testing.T) {
-	ts := testServer(http.StatusOK, "./testdata/response/name_search.xml")
-	defer ts.Close()
+	t.Run("Basic Usage", func(t *testing.T) {
+		ts := testServer(http.StatusOK, "./testdata/response/name_search.xml")
+		defer ts.Close()
 
-	SetAppID("your-token")
-	setTestEnvToRequest(ts)
+		SetAppID("your-token")
+		setTestEnvToRequest(ts)
 
-	res, err := NameSearch("フィルイン", "10202")
-	if err != nil {
-		t.Errorf("error! %v", err)
-	}
+		res, err := NameSearch("フィルイン", "10202")
+		if err != nil {
+			t.Errorf("error! %v", err)
+		}
 
-	if res.Count != 1 {
-		t.Errorf("count value is wrong. result:%d expected:%d", res.Count, 1)
-	}
+		if res.Count != 1 {
+			t.Errorf("count value is wrong. result:%d expected:%d", res.Count, 1)
+		}
 
-	if len(res.Corporations) != 1 {
-		t.Errorf("corporations length is wtong. result:%d expected:%d", len(res.Corporations), 1)
-	}
+		if len(res.Corporations) != 1 {
+			t.Errorf("corporations length is wtong. result:%d expected:%d", len(res.Corporations), 1)
+		}
 
-	if res.Corporations[0].CorporateNumber != testFillinCorpNum {
-		t.Errorf("corporation name is wtong. result:%d expected:%d", res.Corporations[0].CorporateNumber, testFillinCorpNum)
-	}
+		if res.Corporations[0].CorporateNumber != testFillinCorpNum {
+			t.Errorf("corporation name is wtong. result:%d expected:%d", res.Corporations[0].CorporateNumber, testFillinCorpNum)
+		}
 
-	if res.Corporations[0].Name != "株式会社フィルイン" {
-		t.Errorf("corporation name is wtong. result:%s expected:%s", res.Corporations[0].Name, "株式会社フィルイン")
-	}
+		if res.Corporations[0].Name != "株式会社フィルイン" {
+			t.Errorf("corporation name is wtong. result:%s expected:%s", res.Corporations[0].Name, "株式会社フィルイン")
+		}
+	})
+
+	t.Run("Errors", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			searchName    string
+			address       string
+			statusCode    int
+			contentType   string
+			content       string
+			expectedError string
+		}{
+			{
+				"HTTP_Status_400",
+				"フィルイン",
+				"10202",
+				http.StatusBadRequest,
+				"application/csv",
+				"101,商号又は名称には（全角文字|半角英数字記号）をutf-8でエンコードして設定してください。。",
+				"101:商号又は名称には（全角文字|半角英数字記号）をutf-8でエンコードして設定してください。。",
+			},
+			{
+				"HTTP_Status_403",
+				"フィルイン",
+				"10202",
+				http.StatusForbidden,
+				"text/html",
+				"",
+				"同一アプリケーションIDで一定期間内に多数のアクセスが実行されたため制限されています。",
+			},
+			{
+				"HTTP_Status_404",
+				"フィルイン",
+				"10202",
+				http.StatusNotFound,
+				"text/html",
+				"",
+				"アプリケーションIDが登録されていないまたは無効です。",
+			},
+			{
+				"HTTP_Status_500",
+				"フィルイン",
+				"10202",
+				http.StatusInternalServerError,
+				"text/html",
+				"",
+				"法人番号システム Web-API に問題が発生しています。",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				ts := testErrorServer(test.statusCode, test.contentType, test.content)
+				defer ts.Close()
+
+				SetAppID("your-token")
+				setTestEnvToRequest(ts)
+
+				_, err := NameSearch(test.searchName, test.address)
+				if err == nil {
+					t.Errorf("No error occurred.")
+				}
+
+				if strings.TrimSpace(err.Error()) != test.expectedError {
+					t.Errorf("Unexpected error received: %s, expected: %s", err.Error(), test.expectedError)
+				}
+			})
+		}
+	})
 }
 
 func TestSetAppID(t *testing.T) {
@@ -186,13 +451,21 @@ func TestSetAppID(t *testing.T) {
 
 func testServer(statusCode int, xmlPath string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(statusCode)
 		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(statusCode)
 		data, _ := os.ReadFile(xmlPath)
 		_, err := w.Write(data)
 		if err != nil {
 			panic(err)
 		}
+	}))
+}
+
+func testErrorServer(statusCode int, contentType string, content string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(statusCode)
+		fmt.Fprintln(w, content)
 	}))
 }
 

--- a/corp_test.go
+++ b/corp_test.go
@@ -18,7 +18,7 @@ var (
 
 func TestByNumber(t *testing.T) {
 	t.Run("simgle corporate number", func(t *testing.T) {
-		ts := testServer("./testdata/response/by_number.xml")
+		ts := testServer(http.StatusOK, "./testdata/response/by_number.xml")
 		defer ts.Close()
 
 		SetAppID("your-token")
@@ -47,7 +47,7 @@ func TestByNumber(t *testing.T) {
 	})
 
 	t.Run("multiple corporate numbers", func(t *testing.T) {
-		ts := testServer("./testdata/response/by_numbers.xml")
+		ts := testServer(http.StatusOK, "./testdata/response/by_numbers.xml")
 		defer ts.Close()
 
 		SetAppID("your-token")
@@ -85,7 +85,7 @@ func TestByNumber(t *testing.T) {
 }
 
 func TestByNumberWithHistory(t *testing.T) {
-	ts := testServer("./testdata/response/by_number_with_history.xml")
+	ts := testServer(http.StatusOK, "./testdata/response/by_number_with_history.xml")
 	defer ts.Close()
 
 	SetAppID("your-token")
@@ -118,7 +118,7 @@ func TestByNumberWithHistory(t *testing.T) {
 }
 
 func TestDiffSearch(t *testing.T) {
-	ts := testServer("./testdata/response/diff_search.xml")
+	ts := testServer(http.StatusOK, "./testdata/response/diff_search.xml")
 	defer ts.Close()
 
 	SetAppID("your-token")
@@ -147,7 +147,7 @@ func TestDiffSearch(t *testing.T) {
 }
 
 func TestNameSearch(t *testing.T) {
-	ts := testServer("./testdata/response/name_search.xml")
+	ts := testServer(http.StatusOK, "./testdata/response/name_search.xml")
 	defer ts.Close()
 
 	SetAppID("your-token")
@@ -184,8 +184,9 @@ func TestSetAppID(t *testing.T) {
 	}
 }
 
-func testServer(xmlPath string) *httptest.Server {
+func testServer(statusCode int, xmlPath string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
 		w.Header().Set("Content-Type", "application/xml")
 		data, _ := os.ReadFile(xmlPath)
 		_, err := w.Write(data)
@@ -204,7 +205,7 @@ func setTestEnvToRequest(ts *httptest.Server) {
 func ExampleByNumber() {
 	// テスト環境用の設定
 	// 実際に利用する際には不要
-	ts := testServer("./testdata/response/by_number.xml")
+	ts := testServer(http.StatusOK, "./testdata/response/by_number.xml")
 	setTestEnvToRequest(ts)
 	defer ts.Close()
 
@@ -222,7 +223,7 @@ func ExampleByNumber() {
 func ExampleDiffSearch() {
 	// テスト環境用の設定
 	// 実際に利用する際には不要
-	ts := testServer("./testdata/response/diff_search.xml")
+	ts := testServer(http.StatusOK, "./testdata/response/diff_search.xml")
 	setTestEnvToRequest(ts)
 	defer ts.Close()
 
@@ -241,7 +242,7 @@ func ExampleDiffSearch() {
 func ExampleNameSearch() {
 	// テスト環境用の設定
 	// 実際に利用する際には不要
-	ts := testServer("./testdata/response/name_search.xml")
+	ts := testServer(http.StatusOK, "./testdata/response/name_search.xml")
 	setTestEnvToRequest(ts)
 	defer ts.Close()
 

--- a/corp_test.go
+++ b/corp_test.go
@@ -19,7 +19,7 @@ var (
 
 func TestByNumber(t *testing.T) {
 	t.Run("Basic Usage", func(t *testing.T) {
-		ts := testServer(http.StatusOK, "./testdata/response/by_number.xml")
+		ts := testServer("./testdata/response/by_number.xml")
 		defer ts.Close()
 
 		SetAppID("your-token")
@@ -48,7 +48,7 @@ func TestByNumber(t *testing.T) {
 	})
 
 	t.Run("Multiple Corporate Numbers", func(t *testing.T) {
-		ts := testServer(http.StatusOK, "./testdata/response/by_numbers.xml")
+		ts := testServer("./testdata/response/by_numbers.xml")
 		defer ts.Close()
 
 		SetAppID("your-token")
@@ -146,7 +146,7 @@ func TestByNumber(t *testing.T) {
 
 func TestByNumberWithHistory(t *testing.T) {
 	t.Run("Basic Usage", func(t *testing.T) {
-		ts := testServer(http.StatusOK, "./testdata/response/by_number_with_history.xml")
+		ts := testServer("./testdata/response/by_number_with_history.xml")
 		defer ts.Close()
 
 		SetAppID("your-token")
@@ -239,7 +239,7 @@ func TestByNumberWithHistory(t *testing.T) {
 
 func TestDiffSearch(t *testing.T) {
 	t.Run("Basic Usage", func(t *testing.T) {
-		ts := testServer(http.StatusOK, "./testdata/response/diff_search.xml")
+		ts := testServer("./testdata/response/diff_search.xml")
 		defer ts.Close()
 
 		SetAppID("your-token")
@@ -343,7 +343,7 @@ func TestDiffSearch(t *testing.T) {
 
 func TestNameSearch(t *testing.T) {
 	t.Run("Basic Usage", func(t *testing.T) {
-		ts := testServer(http.StatusOK, "./testdata/response/name_search.xml")
+		ts := testServer("./testdata/response/name_search.xml")
 		defer ts.Close()
 
 		SetAppID("your-token")
@@ -449,10 +449,10 @@ func TestSetAppID(t *testing.T) {
 	}
 }
 
-func testServer(statusCode int, xmlPath string) *httptest.Server {
+func testServer(xmlPath string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/xml")
-		w.WriteHeader(statusCode)
+		w.WriteHeader(http.StatusOK)
 		data, _ := os.ReadFile(xmlPath)
 		_, err := w.Write(data)
 		if err != nil {
@@ -478,7 +478,7 @@ func setTestEnvToRequest(ts *httptest.Server) {
 func ExampleByNumber() {
 	// テスト環境用の設定
 	// 実際に利用する際には不要
-	ts := testServer(http.StatusOK, "./testdata/response/by_number.xml")
+	ts := testServer("./testdata/response/by_number.xml")
 	setTestEnvToRequest(ts)
 	defer ts.Close()
 
@@ -496,7 +496,7 @@ func ExampleByNumber() {
 func ExampleDiffSearch() {
 	// テスト環境用の設定
 	// 実際に利用する際には不要
-	ts := testServer(http.StatusOK, "./testdata/response/diff_search.xml")
+	ts := testServer("./testdata/response/diff_search.xml")
 	setTestEnvToRequest(ts)
 	defer ts.Close()
 
@@ -515,7 +515,7 @@ func ExampleDiffSearch() {
 func ExampleNameSearch() {
 	// テスト環境用の設定
 	// 実際に利用する際には不要
-	ts := testServer(http.StatusOK, "./testdata/response/name_search.xml")
+	ts := testServer("./testdata/response/name_search.xml")
 	setTestEnvToRequest(ts)
 	defer ts.Close()
 


### PR DESCRIPTION
fixed #19 

* HTTP Status が 400, 403, 404, 500 の場合のエラー処理を追加
    - 対象エラーは [PDF](https://www.houjin-bangou.nta.go.jp/pc/webapi/images/k-web-api-kinou-gaiyo.pdf) 末尾の別紙
* 該当のエラーレスポンスの場合には err を返す
